### PR TITLE
Fix issues preventing game launch

### DIFF
--- a/src/main/java/lol/hyper/customlauncher/login/LaunchGame.java
+++ b/src/main/java/lol/hyper/customlauncher/login/LaunchGame.java
@@ -76,6 +76,11 @@ public final class LaunchGame extends Thread {
 
         String[] launchCommand = null;
 
+        // run the TTR updater
+        TTRUpdater ttrUpdater = new TTRUpdater();
+        ttrUpdater.setVisible(true);
+        ttrUpdater.checkUpdates(manifest);
+
         switch (OSDetection.osType) {
             case "linux" -> {
                 launchCommand = new String[]{"./TTREngine"};
@@ -110,11 +115,6 @@ public final class LaunchGame extends Thread {
             new PopUpWindow(null, "Unable to determine operating system!");
             return;
         }
-
-        // run the TTR updater
-        TTRUpdater ttrUpdater = new TTRUpdater();
-        ttrUpdater.setVisible(true);
-        ttrUpdater.checkUpdates(manifest);
 
         logger.info("Launching game from " + installPath.getAbsolutePath());
 

--- a/src/main/java/lol/hyper/customlauncher/login/LoginHandler.java
+++ b/src/main/java/lol/hyper/customlauncher/login/LoginHandler.java
@@ -188,7 +188,13 @@ public class LoginHandler {
         HashMap<String, String> receivedDetails = new HashMap<>();
 
         for (String x : responseJSON.keySet()) {
-            receivedDetails.put(x, responseJSON.getString(x));
+            if (!responseJSON.isNull(x)) {
+                receivedDetails.put(x, responseJSON.getString(x));
+            }
+            else {
+                receivedDetails.put(x, null);
+                logger.warn("Value of '" + x + "' in login response was null.");
+            }
         }
 
         try {

--- a/src/main/java/lol/hyper/customlauncher/windows/NewAccountWindow.java
+++ b/src/main/java/lol/hyper/customlauncher/windows/NewAccountWindow.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import java.awt.event.ItemEvent;
-import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/lol/hyper/customlauncher/windows/NewAccountWindow.java
+++ b/src/main/java/lol/hyper/customlauncher/windows/NewAccountWindow.java
@@ -133,8 +133,8 @@ public class NewAccountWindow extends JFrame {
             boolean secretIsEmpty = secretPhraseField.getPassword().length == 0;
             boolean encrypt = encryptedCheck.isSelected();
             String enteredUsername = usernameTextField.getText();
-            String enteredPassword = Arrays.toString(passwordField.getPassword());
-            String enteredPassphrase = Arrays.toString(secretPhraseField.getPassword());
+            String enteredPassword = String.valueOf(passwordField.getPassword());
+            String enteredPassphrase = String.valueOf(secretPhraseField.getPassword());
 
             if (usernameIsEmpty || passwordIsEmpty) {
                 JOptionPane.showMessageDialog(this, "You must fill in all text boxes.", "Error", JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/lol/hyper/customlauncher/windows/NewAccountWindow.java
+++ b/src/main/java/lol/hyper/customlauncher/windows/NewAccountWindow.java
@@ -39,7 +39,7 @@ public class NewAccountWindow extends JFrame {
     /**
      * The regex for no special characters.
      */
-    private final Pattern NO_SPECIAL_CHARACTERS = Pattern.compile("^[a-zA-Z0-9_.-]*$");
+    private final Pattern NO_SPECIAL_CHARACTERS = Pattern.compile("^[a-zA-Z0-9\\s_.-]*$");
 
     /**
      * Creates a new account window.


### PR DESCRIPTION
This PR fixes a chain of issues which prevented logging into the game.

#### Password formatting bug 656b1c9c67348585738d05e22c82df302d0e4d47
Fixed a bug where passwords were stored as a string containing an array (e.g. `"[p, a, s, s, w, o, r, d]"`) causing logins to fail due to the incorrect password. I assume this is not the intended format, so I reverted it back to regular strings.

#### Handle null values in login response  (due to newly added field) 253bae1d6d7d124d02b909a0578942653f9c53e6
This prevented login,  since TTR just added a new field to their response field, `ip`, which is always `null` for now since its not being used yet. This broke CLR, so I added some logic to handle `null` response fields.

#### Move update check after Linux permission check 5b7201d55232c3ace5e5c34bc04b8d354dace04e
This prevents a bug which prevented login on fresh Linux installs due to checking file permissions before the files existed.

#### Allow whitespace in usernames 530de46d7bb9ade9d864972744150af7d34dc151
Since TTR does in fact allow spaces (and one of my accounts has a space in it, too).

With that said, a new release incorporating this + your 300 commits of updates would be awesome :)