### PR TITLE
[QoL] Improve update checking speed; fix minor bugs

### DIFF
--- a/linux/run.sh
+++ b/linux/run.sh
@@ -17,7 +17,7 @@
 #
 
 # Check if Java is installed and the version is at least 17
-if java -version 2>&1 | grep -q "version \"17"; then
+if (( $(java -version 2>&1 | grep -Po '(?<=")[0-9]{2}') >= 17 )); then
     latest=$(ls -t CustomLauncherRewrite-*.jar | head -n1)
     java -jar "$latest"
 else

--- a/src/main/java/lol/hyper/customlauncher/ttrupdater/TTRUpdater.java
+++ b/src/main/java/lol/hyper/customlauncher/ttrupdater/TTRUpdater.java
@@ -170,7 +170,7 @@ public class TTRUpdater extends JFrame {
                 if (!localFile.exists()) {
                     logger.info("-----------------------------------------------------------------------");
                     logger.info(installPath.getAbsolutePath() + File.separator + key);
-                    logger.info("This file is keymissing and will be downloaded.");
+                    logger.info("This file is missing and will be downloaded.");
                     filesToDownload.add(key);
                     continue;
                 }
@@ -191,7 +191,7 @@ public class TTRUpdater extends JFrame {
                     
                         cacheJSON.put(key, localHash);
                     }
-                    
+
                     //Otherwise, just use the cached hash
                     else localHash = cacheJSON.getString(key);
                 } catch (Exception exception) {

--- a/src/main/java/lol/hyper/customlauncher/windows/MainWindow.java
+++ b/src/main/java/lol/hyper/customlauncher/windows/MainWindow.java
@@ -44,6 +44,12 @@ public final class MainWindow extends JFrame {
      * The list of accounts used to display on the main window.
      */
     private final DefaultListModel<Account> accountsModel = new DefaultListModel<>();
+
+    /**
+     * Config instance
+     */  
+    public final ConfigHandler configHandler = new ConfigHandler();
+
     /**
      * Accounts currently loaded.
      */
@@ -69,9 +75,6 @@ public final class MainWindow extends JFrame {
         } catch (Exception exception) {
             throw new RuntimeException(exception);
         }
-
-        // Config instance
-        ConfigHandler configHandler = new ConfigHandler();
 
         // tracker stuff
         InvasionTrackerPanel invasionTracker = new InvasionTrackerPanel(configHandler);


### PR DESCRIPTION
#### Cache file hashes to speedup update checking dee859c04b1b9e4bd0a5b851b830cdad9c881e04
This stores local TTR file hashes on disk, rather than being re-calculated at every login. This vastly improves TTR update check times when no update is needed, from around ~5 seconds to less than a second on my laptop; especially useful when opening multiple toons in a row. The only downside I could think of is that if files are somehow corrupted or deleted outside of the launcher, it won't automatically be fixed until another TTR update modifies that file. Let me know what you think about this.

#### Initialize ConfigHandler before Accounts 2c69b1bebdaf470a340e7536e00b741eda10c2fd
While building the previous commit, I ran into a small bug with out of order operations, where on first launch the attempt to create `config/accounts.json` happens before the `config` directory is created. This fixes it by initializing `configHandler` - which creates the directory - before its needed.

#### Check if Java version is greater than 17 rather than equal to 17 c052e883bc98c99bc942b14717b5d43202d416c0
The Linux java check only checked if the version was equal to 17 instead of greater than or equal to. Most distros use Java 17 so it worked, but I tried on a rolling release (Java 21) and ran into this.

On a side note, have you thought about implementing delta patching?

And also, thank you for adding me to the new About page! 